### PR TITLE
added libcurl to library path in envs

### DIFF
--- a/packages/avalanche.py
+++ b/packages/avalanche.py
@@ -39,6 +39,7 @@ class Avalanche(localpackage.LocalPackage):
                "LD_LIBRARY_PATH" : os.path.join(self._dependency_paths[self._root_dep], "lib")}
         if self._dependency_paths[self._curl_dep] is not None: # Conditional package
             env["PATH"] += ":" + os.path.join(self._dependency_paths[self._curl_dep], "bin")
+            env["LD_LIBRARY_PATH"] += ":" + os.path.join(self._dependency_paths[self._curl_dep], "lib")
         self._system.execute_command("make", [], self.get_install_path(), env=env)
     def _update(self):
         """ Special updater for rat-tools, just git pull then install again."""

--- a/packages/rat.py
+++ b/packages/rat.py
@@ -132,6 +132,7 @@ class RatDevelopment(Rat):
         self._env_file.append_library_path(os.path.join(self._dependency_paths["clhep-2.1.1.0"], "lib"))
         if self._dependency_paths["curl-7.26.0"] is not None: # Conditional Package
             self._env_file.append_path(os.path.join(self._dependency_paths["curl-7.26.0"], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths["curl-7.26.0"], "lib"))
         if self._dependency_paths["bzip2-1.0.6"] is not None: # Conditional Package
             self._env_file.add_environment("BZIPROOT", self._dependency_paths["bzip2-1.0.6"])
             self._env_file.append_library_path(os.path.join(self._dependency_paths["bzip2-1.0.6"], "lib"))

--- a/packages/ratreleases.py
+++ b/packages/ratreleases.py
@@ -51,6 +51,7 @@ class RatRelease4(rat.RatRelease):
                                                        "lib/cpp"))
         if self._dependency_paths[self._curl_dep] is not None: # Conditional Package
             self._env_file.append_path(os.path.join(self._dependency_paths[self._curl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths[self._curl_dep], "lib"))
         if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
             self._env_file.add_environment("BZIPROOT", self._dependency_paths[self._bzip_dep])
             self._env_file.append_library_path(os.path.join(self._dependency_paths[self._bzip_dep], 
@@ -90,6 +91,7 @@ class RatRelease3(rat.RatRelease):
                                                         "lib/cpp"))
         if self._dependency_paths[self._curl_dep] is not None: # Conditional Package
             self._env_file.append_path(os.path.join(self._dependency_paths[self._curl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths[self._curl_dep], "lib"))
         if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
             self._env_file.add_environment("BZIPROOT", self._dependency_paths[self._bzip_dep])
             self._env_file.append_library_path(os.path.join(self._dependency_paths[self._bzip_dep], 
@@ -123,6 +125,7 @@ class RatRelease2(rat.RatRelease):
                                                         "lib"))
         if self._dependency_paths[self._curl_dep] is not None: # Conditional Package
             self._env_file.append_path(os.path.join(self._dependency_paths[self._curl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths[self._curl_dep], "lib"))
         if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
             self._env_file.add_environment("BZIPROOT", self._dependency_paths[self._bzip_dep])
             self._env_file.append_library_path(os.path.join(self._dependency_paths[self._bzip_dep], 

--- a/packages/snogoggles.py
+++ b/packages/snogoggles.py
@@ -90,6 +90,7 @@ class Snogoggles(localpackage.LocalPackage):
 
         if self._dependency_paths[self._curl_dep] is not None:
             self._env_file.append_path(os.path.join(self._dependency_paths[self._curl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependence_paths[self._curl_dep], "lib"))
         self._env_file.append_path(os.path.join(self.get_install_path(), "bin"))
         self._env_file.append_path(os.path.join(self._dependency_paths[self._root_dep], "bin"))
         self._env_file.append_path(os.path.join(self._dependency_paths[self._clhep_dep], "bin"))


### PR DESCRIPTION
RAT crashes with an error if using an outdated libcurl - the library path should be extended to include the installed version of libcurl.
