### PR TITLE
Small bug fix for Ubuntu installation of snogoggles

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -205,7 +205,6 @@ class System(object):
             if os.path.exists(temp_dir): # Delete temp if it exits
                 shutil.rmtree(temp_dir)
             temp_dir = self.build_path(temp_dir)
-            print str(os.path.join(self.get_cache_path(), file_name))
 	    tar_file = tarfile.open(str(os.path.join(self.get_cache_path(), file_name)))		    
             tar_file.__class__ = snoing_tarfile.TarFile
             tar_file.extractall(temp_dir)


### PR DESCRIPTION
This fixes the problem where ubuntu machines (at least my machine) cannot correctly download the sfml packages into snogoggles. This might be a ubuntu version specific problem but opening strings in python using str(....) should make things more compatible with different linux machines. 
