### PR TITLE
Add configuration flag for position-independent code to fftw Installation

### DIFF
--- a/packages/fftw.py
+++ b/packages/fftw.py
@@ -35,7 +35,7 @@ class Fftw(conditionallibrarypackage.ConditionalLibraryPackage):
         """ Install fftw."""
         source_path = os.path.join(self._system.get_install_path(), "%s-source" % self._name)
         self._system.untar_file(self._tar_name, source_path, 1)
-        self._system.execute_command("./configure", cwd=source_path)
+        self._system.execute_command("./configure", ['--with-pic'], cwd=source_path)
         self._system.execute_command("make", cwd=source_path)
         self._system.execute_command("make", ["install", "prefix=%s" % self.get_install_path()], cwd=source_path)
         if self._system.get_install_mode() == installmode.Grid:


### PR DESCRIPTION
When I was updating our software installation at Oxford to include @mjmottram 's fftw additions, I found that ROOT was no longer compiling.  The error message stated that the fftw library had not been compiled with the -fPIC flag enabled, and so this fixes that.  Both fftw and ROOT now compile with no errors.

(Bit odd that this change is even required, since @mjmottram said that he tested it on Mac and it was fine ... perhaps it's something specific to the compiler being used at Oxford?)
