### PR TITLE
Fix install

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -28,7 +28,7 @@ class Logger(object):
         if not os.path.exists(self._install_file):
             file_ = open(self._install_file, "w")
             file_.write(("## SNOING\nThis is a snoing install directory. Please alter only with"
-                         "snoing at %s") % __file__)
+                         "snoing at %s \n") % __file__)
             file_.close()
     def end(self):
         """ Stop logging, cleanup resources."""

--- a/core/system.py
+++ b/core/system.py
@@ -246,7 +246,7 @@ class System(object):
     def find_library(self, library):
         """ Search the system for a library, return its location if found otherwise return None."""
         try:
-            location = self.execute_command("which", [library])[0]
+            location = self.execute_command("which", [library])
         except:
             return None        
         if location == "\n" or location == "":

--- a/packages/bzip2.py
+++ b/packages/bzip2.py
@@ -7,6 +7,7 @@
 # Author O Wasalski - 13/06/2012 <wasalski@berkeley.edu> : First revision, new file
 # Author P G Jones - 23/06/2012 <p.g.jones@qmul.ac.uk> : Refactor of Package Structure 
 # Author P G Jones - 22/09/2012 <p.g.jones@qmul.ac.uk> : Major refactor of snoing.
+# Author K E Gilje - 10/09/2018 <gilje@ualberta.ca> : Update bzip2 location.
 ####################################################################################################
 import conditionallibrarypackage
 import os
@@ -29,7 +30,7 @@ class Bzip2(conditionallibrarypackage.ConditionalLibraryPackage):
             self._system.library_exists("libbz2", os.path.join(self.get_install_path(), "lib"))
     def _download(self):
         """ Download the tar file."""
-        self._system.download_file("http://www.bzip.org/1.0.6/" + self._tar_name)
+        self._system.download_file("http://gentoo.mirrors.tera-byte.com/distfiles/" + self._tar_name)
     def _install( self ):
         """ Install bzip2."""
         self._system.untar_file(self._tar_name, self.get_install_path(), 1)

--- a/packages/dispatcher.py
+++ b/packages/dispatcher.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# Disp: Dispatcher for SNO+ data
+#
+# Git clones dispatcher and installs it
+#
+# Author K E Gilje - 06/09/2018 <gilje@ualberta.ca> : First revision
+####################################################################################################
+import localpackage
+import os
+
+class Dispatcher(localpackage.LocalPackage):
+    """ Base class for dispatcher."""
+    def __init__(self, name, system):
+        """ Initialise dispatcher."""
+        super(Dispatcher, self).__init__(name, system)
+    def get_dependencies(self):
+        """ No External Dependencies."""
+        return []
+    def _is_downloaded(self):
+        """ Check if downloaded."""
+        return os.path.exists(self.get_install_path())
+    def _is_installed(self):
+        return self._system.library_exists("libconthost", os.path.join(self.get_install_path(), 
+                                                                       "lib"))
+    def _download(self):
+        """ Git clone dispatcher."""
+        self._system.execute_command("git", ["clone", "https://github.com/snoplus/disp.git",
+                                             self.get_install_path()],
+                                     verbose=True)
+    def _install(self):
+        """ Install Dispatcher."""
+        self._system.execute_command("make", [], self.get_install_path())
+    def _update(self):
+        """ Special updater for Dispatcher, just git pull then install again."""
+        self._system.execute_command("git", ["pull"], cwd=self.get_install_path(), verbose=True)
+        self._install()

--- a/packages/geant4.py
+++ b/packages/geant4.py
@@ -29,6 +29,8 @@ class Geant4Post5(LocalPackage):
         dependencies = ['make', 'g++', 'gcc', 'cmake-2.8.12', self._xerces_dep]
         if self._system.get_install_mode() == installmode.Graphical:
             dependencies.extend(['Xm', 'Xt', 'opengl', 'Xmu', 'Xi'])
+        if self._system.get_install_mode() != installmode.Grid:
+            dependencies.extend(['expat'])
         return dependencies
 
     def _is_downloaded(self):

--- a/packages/gsl.py
+++ b/packages/gsl.py
@@ -6,6 +6,7 @@
 #
 # Author:
 #  - 2015-06-05 M Mottram <m.mottram@qmul.ac.uk> first instance
+# Author K E Gilje 2018-09-10 <gilje@ualberta.ca> : Fixing the prefix of gsl to point to the right location.
 ####################################################################################################
 import conditionallibrarypackage
 import installmode
@@ -36,8 +37,8 @@ class Gsl(conditionallibrarypackage.ConditionalLibraryPackage):
         """ Install gsl."""
         source_path = os.path.join(self._system.get_install_path(), "%s-source" % self._name)
         self._system.untar_file(self._tar_name, source_path, 1)
-        self._system.execute_command("./configure", ["--with-pic"], cwd=source_path)
+        self._system.execute_command("./configure", ["--with-pic", "--prefix=%s" % self.get_install_path()], cwd=source_path)
         self._system.execute_command("make", cwd=source_path)
-        self._system.execute_command("make", ["install", "prefix=%s" % self.get_install_path()], cwd=source_path)
+        self._system.execute_command("make", ["install"], cwd=source_path)
         if self._system.get_install_mode() == installmode.Grid:
             shutil.rmtree(source_path)

--- a/packages/postgresql.py
+++ b/packages/postgresql.py
@@ -63,7 +63,8 @@ class PostgreSQL(conditionallibrarypackage.ConditionalLibraryPackage):
         """ Just install the client libraries"""
         source_path = os.path.join(self._system.get_install_path(), "%s-source" % self._name)
         self._system.untar_file(self.get_tar_name(), source_path, 1)
-        self._system.configure_command(args=["prefix=%s" % self.get_install_path()], cwd=source_path)
+        self._system.configure_command(args=["prefix=%s" % self.get_install_path(), "--without-readline"],
+                                       cwd=source_path)
         self._system.execute_command("make", [], source_path)
         self._system.execute_command("make", ["-C", "src/bin", "install"], source_path)
         self._system.execute_command("make", ["-C", "src/include", "install"], source_path)

--- a/packages/rat.py
+++ b/packages/rat.py
@@ -135,7 +135,7 @@ class RatDevelopment(Rat):
 
     def _get_dependencies(self):
         """Return the extra dependencies."""
-        return ['curl-7.26.0', 'bzip2-1.0.6']
+        return ['curl-7.26.0', 'gsl-1.16', 'bzip2-1.0.6']
 
     def _is_downloaded(self):
         """Check if tarball has been downloaded."""
@@ -143,7 +143,7 @@ class RatDevelopment(Rat):
 
     def _download(self):
         """Git clone rat-dev."""
-        self._system.execute_command('git', ['clone', 'git@github.com:snoplus/rat.git', self.get_install_path()], 
+        self._system.execute_command('git', ['clone', 'https://github.com/snoplus/rat.git', self.get_install_path()], 
                                      verbose=True)
 
     def _write_env_file(self):
@@ -155,6 +155,9 @@ class RatDevelopment(Rat):
         if self._dependency_paths['curl-7.26.0'] is not None:
             self._env_file.append_path(os.path.join(self._dependency_paths['curl-7.26.0'], 'bin'))
             self._env_file.append_library_path(os.path.join(self._dependency_paths['curl-7.26.0'], 'lib'))
+        if self._dependency_paths['gsl-1.16'] is not None:
+            self._env_file.append_path(os.path.join(self._dependency_paths['gsl-1.16'], 'bin'))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths['gsl-1.16'], 'lib'))
         if self._dependency_paths['bzip2-1.0.6'] is not None:
             self._env_file.add_environment('BZIPROOT', self._dependency_paths['bzip2-1.0.6'])
             self._env_file.append_library_path(os.path.join(self._dependency_paths['bzip2-1.0.6'], 'lib'))

--- a/packages/ratreleases.py
+++ b/packages/ratreleases.py
@@ -23,14 +23,15 @@ class RatRelease6(rat.RatRelease):
                                           tar_name)
         self._curl_dep = "curl-7.26.0"
         self._bzip_dep = "bzip2-1.0.6"
+        self._gsl_dep = "gsl-1.16"
         self._postgres_dep = "postgresql-9.5.2"
         self._require_postgres = postgres
     def _get_dependencies(self):
         """ Return the extra dependencies."""        
         if self._require_postgres is True:
-            return [self._curl_dep, self._bzip_dep, self._postgres_dep]
+            return [self._curl_dep, self._bzip_dep, self._gsl_dep, self._postgres_dep]
         else:
-            return [self._curl_dep, self._bzip_dep]            
+            return [self._curl_dep, self._bzip_dep, self._gsl_dep]
     def _write_env_file(self):
         """ Diff geant env file and no need to patch rat."""
         self._env_file.add_source(self._dependency_paths[self._geant_dep], "bin/geant4")
@@ -42,6 +43,9 @@ class RatRelease6(rat.RatRelease):
             self._env_file.add_environment("BZIPROOT", self._dependency_paths[self._bzip_dep])
             self._env_file.append_library_path(os.path.join(self._dependency_paths[self._bzip_dep], 
                                                           "lib"))
+        if self._dependency_paths[self._gsl_dep] is not None: # Conditional Package
+            self._env_file.append_path(os.path.join(self._dependency_paths[self._gsl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths[self._gsl_dep], "lib"))
         if self._require_postgres is True and self._dependency_paths[self._postgres_dep] is not None: # Conditional Package
             self._env_file.append_path(os.path.join(self._dependency_paths[self._postgres_dep], "bin"))
             self._env_file.append_library_path(os.path.join(self._dependency_paths[self._postgres_dep], "lib"))

--- a/packages/xsnoed.py
+++ b/packages/xsnoed.py
@@ -5,6 +5,7 @@
 # Installers for xsnoed
 #
 # Author P G Jones - 2014-02-03 <p.g.jones@qmul.ac.uk> : First revision
+# Author K E Gilje - 2018-09-10 <gilje@ualberta.ca> : Explicitly add dependencies and handle local bzip2.
 ####################################################################################################
 import localpackage
 import os

--- a/packages/xsnoed.py
+++ b/packages/xsnoed.py
@@ -20,9 +20,14 @@ class Xsnoed(localpackage.LocalPackage):
         self._geant_dep = geant_dep
         self._rat_dep = rat_dep
         self._rattools_dep = rattools_dep
+        self._curl_dep  = "curl-7.26.0"
+        self._disp_dep = "disp"
+        self._motif_dep = "Xm"
+        self._bzip_dep = "bzip2-1.0.6"
     def get_dependencies(self):
         """ Return the dependency names as a list of names."""
-        return [self._root_dep, self._geant_dep, self._rat_dep, self._rattools_dep, "Xm"]
+        return [self._root_dep, self._geant_dep, self._rat_dep, self._rattools_dep,
+                self._curl_dep, self._disp_dep, self._motif_dep, self._bzip_dep]
     def _is_installed(self):
         """ Xsnoed releases and dev share a common install check."""
         # Check xsnoed
@@ -33,8 +38,13 @@ class Xsnoed(localpackage.LocalPackage):
         self.write_env_file()
         # Write the command file and source it...
         command_text = """#!/bin/bash\nsource %s\ncd %s\nmake""" % \
-            (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name), 
-             self.get_install_path())
+                       (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name), 
+                        self.get_install_path())
+        # Explicitly add BZIP2 to the library path here if BZIP2 was installed locally
+        if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
+            command_text = """#!/bin/bash\nsource %s\ncd %s\nmake LDFLAGS='-L%s'""" % \
+                           (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name),
+                            self.get_install_path(), self._dependency_paths[self._bzip_dep])
         self._system.execute_complex_command(command_text)
     def _remove(self):
         """ Delete the env files as well."""
@@ -47,6 +57,14 @@ class Xsnoed(localpackage.LocalPackage):
         self._env_file.add_source(os.path.join(self._dependency_paths[self._geant_dep], "bin"), "geant4")
         self._env_file.add_source(self._dependency_paths[self._rat_dep], "env")
         self._env_file.add_source(os.path.join(self._dependency_paths[self._rattools_dep], "ratzdab"), "env")
+        self._env_file.add_source(os.path.join(self._dependency_paths[self._disp_dep]), "env")
+        if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
+            self._env_file.add_environment('BZIPROOT', self._dependency_paths[self._bzip_dep])
+            self._env_file.append_library_path(self._dependency_paths[self._bzip_dep])
+        if self._dependency_paths[self._curl_dep] is not None: # Conditional Package
+            self._env_file.append_path(os.path.join(self._dependency_paths[self._curl_dep], "bin"))
+            self._env_file.append_library_path(os.path.join(self._dependency_paths[self._curl_dep], "lib"))
+        #print self._system.get_install_path()
         self._env_file.write(self._system.get_install_path(), "env_%s" % self._name)
 
 class XsnoedRelease(Xsnoed):
@@ -70,7 +88,7 @@ class XsnoedRelease(Xsnoed):
         else:
             password = getpass.getpass("github password:")
             self._system.download_file(
-                "https://github.com/snoplus/xsnoed/archive/%s.tar.gz" % self._download_name, self._username,
+                "https://github.com/snoplus/xsnoed/tarball/" + self._download_name, self._username,
                 password, file_name = self._tar_name, retries = 3)
     def _install(self):
         """ Release installs must untar first."""
@@ -85,14 +103,15 @@ class XsnoedDevelopment(Xsnoed):
     """ Base xsnoed installer for xsnoed-dev."""
     def __init__(self, name, system):
         """ Initialise xsnoed with the tar_name."""
-        super(XsnoedDevelopment, self).__init__(name, system, "root-5.34.21", "geant4.10.0.p02", 
+        super(XsnoedDevelopment, self).__init__(name, system, "root-5.34.36", "geant4.10.0.p02", 
                                                 "rat-dev", "rattools-dev")
     def _is_downloaded(self):
         """ Check if tarball has been downloaded."""
         return os.path.exists(self.get_install_path())
     def _download(self):
         """ Git clone xsnoed-dev."""
-        self._system.execute_command("git", ["clone", "git@github.com:snoplus/xsnoed.git", self.get_install_path()], 
+        self._system.execute_command("git", ["clone", "https://github.com/snoplus/xsnoed.git", 
+                                             self.get_install_path()], 
                                      verbose=True)
     def _update(self):
         """ Special updater for xsnoed-dev, delete env file write a new then git pull and scons."""
@@ -102,5 +121,10 @@ class XsnoedDevelopment(Xsnoed):
         self._system.remove(os.path.join(self._system.get_install_path(), "env_%s.csh" % self._name))
         super(XsnoedDevelopment, self).write_env_file()
         command_text = "#!/bin/bash\nsource %s\ncd %s\nmake\n" \
-            % (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name), self.get_install_path())
+            % (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name),
+               self.get_install_path())
+        if self._dependency_paths[self._bzip_dep] is not None: # Conditional Package
+            command_text = "#!/bin/bash\nsource %s\ncd %s\nmake LDFLAGS='-L%s'\n" \
+                           % (os.path.join(self._system.get_install_path(), "env_%s.sh" % self._name),
+                              self.get_install_path(), self._dependency_paths[self._bzip_dep])
         self._system.execute_complex_command(command_text, verbose=True)

--- a/versions/dispatcherversions.py
+++ b/versions/dispatcherversions.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+#
+# DispatcherDev
+#
+# The development and release versions of dispatcher.
+#
+# Author K E Gilje - 06/09/2018 <gilje@ualberta.ca> : First revision
+####################################################################################################
+import dispatcher
+
+class DispatcherDev(dispatcher.Dispatcher):
+    def __init__(self, system):
+        """ Initialise dev version."""
+        super(DispatcherDev, self).__init__("disp", system)

--- a/versions/geant4libs.py
+++ b/versions/geant4libs.py
@@ -1,32 +1,38 @@
 #!/usr/bin/env python
 #
-# Xt, Xmu, Xi
+# Xt, Xmu, Xi, Expat
 #
 # Libraries required by geant4
 #
 # Author P G Jones - 22/06/2012 <p.g.jones@qmul.ac.uk> : First revision
 # Author P G Jones - 22/09/2012 <p.g.jones@qmul.ac.uk> : Major refactor of snoing.
+# Author K E Gilje - 05/09/2018 <gilje@ualberta.ca> : Including Expat library check
 ####################################################################################################
 
 import librarypackage
 
+class Expat(librarypackage.LibraryPackage):
+    """Package for the Expat library."""
+    def __init__(self, system):
+        super(Expat, self).__init__('expat', system, 'Install expat-devel on this system.', 'expat',
+                                    ['expat.h'])
 
 class Xt(librarypackage.LibraryPackage):
     """Package for the Xt library."""
     def __init__(self, system):
-        super(Xt, self).__init__('Xt', system, 'Install Xt-dev on this system.', 'Xt',
+        super(Xt, self).__init__('Xt', system, 'Install libXt-devel on this system.', 'Xt',
                                  ['X11/Intrinsic.h'])
 
 
 class Xmu(librarypackage.LibraryPackage):
     """Package for the Xmu library."""
     def __init__(self, system):
-        super(Xmu, self).__init__('Xmu', system, 'Install Xmu-dev on this system.', 'Xmu',
+        super(Xmu, self).__init__('Xmu', system, 'Install Xmu-devel on this system.', 'Xmu',
                                   ['X11/Xmu/Xmu.h'])
 
 
 class Xi(librarypackage.LibraryPackage):
     """Package for the Xi library. """
     def __init__(self, system):
-        super(Xi, self).__init__('Xi', system, 'Install Xi-dev on this system.', 'Xi',
+        super(Xi, self).__init__('Xi', system, 'Install Xi-devel on this system.', 'Xi',
                                  ['X11/extensions/XI.h'])

--- a/versions/rootlibs.py
+++ b/versions/rootlibs.py
@@ -7,6 +7,7 @@
 # Author P G Jones - 13/05/2012 <p.g.jones@qmul.ac.uk> : First revision
 # Author P G Jones - 13/06/2012 <p.g.jones@qmul.ac.uk> : Added extra root libraries
 # Author P G Jones - 22/09/2012 <p.g.jones@qmul.ac.uk> : Major refactor of snoing.
+# Author K E Gilje - 10/09/2018 <gilje@gmail.com> : renaming libraries to CentOS version.
 ####################################################################################################
 
 import commandpackage
@@ -53,19 +54,19 @@ class X11(librarypackage.LibraryPackage):
 class Xpm(librarypackage.LibraryPackage):
     """Package for the xpm-dev library."""
     def __init__(self, system):
-        super(Xpm, self).__init__('Xpm', system, 'Install Xpm-dev on this system.',
+        super(Xpm, self).__init__('Xpm', system, 'Install libXpm-devel on this system.',
                                   'Xpm', ['X11/xpm.h'])
 
 
 class Xft(librarypackage.LibraryPackage):
     """Package for the xft-dev library."""
     def __init__(self, system):
-        super(Xft, self).__init__('Xft', system, 'Install Xft-dev on this system.', 'Xft')
+        super(Xft, self).__init__('Xft', system, 'Install libXft-devel on this system.', 'Xft')
         #'X11/Xft/Xft.h')
 
 
 class Xext(librarypackage.LibraryPackage):
     """Package for the xext-dev library."""
     def __init__(self, system):
-        super(Xext, self).__init__('Xext', system, 'Install the X11 extensions dev on this system.',
+        super(Xext, self).__init__('Xext', system, 'Install the X11 extensions (libXext-devel) on this system.',
                                    'Xext', ['X11/extensions/shape.h'])

--- a/versions/xmlib.py
+++ b/versions/xmlib.py
@@ -14,7 +14,7 @@ import os
 class Xm(systempackage.SystemPackage):
     """ Package for the Open Motif/Xm library."""
     def __init__(self, system):
-        super(Xm, self).__init__("Xm", system, "Install Xm-dev (OpenMotif) on this system.")
+        super(Xm, self).__init__("Xm", system, "Install Xm-dev (OpenMotif or motif-devel) on this system.")
     def check_state(self):
         """ Check the Xm state, slightly more involved on macs."""
         if self._system.get_os_type() == system.System.Mac:

--- a/versions/xsnoedversions.py
+++ b/versions/xsnoedversions.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 #
-# XsnoedDev, Xsnoed1
+# XsnoedDev
 #
 # The xsnoed release versions
 #
 # Author P G Jones - 2014-02-03 <p.g.jones@qmul.ac.uk> : First revision
+# Author K E Gilje - 2018-09-07 <gilje@ualberta.ca> : Removing all but (working) dev version
 ####################################################################################################
 import xsnoed
 
@@ -14,16 +15,10 @@ class XsnoedDev(xsnoed.XsnoedDevelopment):
         """ Initiliase the xsnoed dev package."""
         super(XsnoedDev, self).__init__("xsnoed-dev", system)
 
-class Xsnoed510(xsnoed.XsnoedRelease):
-    """ Xsnoed release 5.1.0, install package."""
-    def __init__(self, system):
-        """ Initiliase the xsnoed 5.1.0 package."""
-        super(Xsnoed510, self).__init__("xsnoed-5.1.0", system, "root-5.34.18", "geant4.9.6.p02",
-                                        "rat-4.5.0", "rattools-4.5.0", "v5.1.0")
-
-class Xsnoed502(xsnoed.XsnoedRelease):
-    """ Xsnoed release 5.0.2, install package."""
-    def __init__(self, system):
-        """ Initiliase the xsnoed 5.0.2 package."""
-        super(Xsnoed502, self).__init__("xsnoed-5.0.2", system, "root-5.34.11", "geant4.9.6.p02",
-                                        "rat-4.5.0", "rattools-4.5.0", "6a7a9d9f5d956c9b89bd01654f242bf26ca0f7de")
+# Commented out to retain format if/when a working version gets released.
+#class Xsnoed530(xsnoed.XsnoedRelease):
+#    """ Xsnoed release 5.3.0, install package."""
+#    def __init__(self, system):
+#        """ Initiliase the xsnoed 5.3.0 package."""
+#        super(Xsnoed530, self).__init__("xsnoed-5.3.0", system, "root-5.34.36", "geant4.10.0.p02",
+#                                        "rat-6.16.0", "rattools-6.16.0", "v5.3.0")


### PR DESCRIPTION
Getting Snoing to actually work from scratch all the way through xsnoed.  I developed this in a virtual box with CentOS7 that was a clean install.  I've also tested this against Cedar (Compute Canada) and against the processing setup for pushing to cvmfs.  Snoing normal install and grid install both worked.  I attempted to test against the graphical install, but that was too much for my virtual box to handle.

Should fix issues #130 ,  #144 , #148  and #118 .

There are some issues with bzip2.  The standard bzip2.org website no longer exists.  My workaround involved getting the source from a gentoo mirror which is not ideal.  May need to consider requiring it as a preinstalled package like snoing does for things like gcc or make.

As a side note, I think issue #117 has been fixed already...
 
