### PR TITLE
Add root6 install

### DIFF
--- a/packages/root.py
+++ b/packages/root.py
@@ -9,6 +9,7 @@
 #        O Wasalski - 13/06/2012 <wasalski@berkeley.edu> : Building python module
 # Author P G Jones - 22/09/2012 <p.g.jones@qmul.ac.uk> : Major refactor of snoing.
 # Author K E Gilje - 10/09/2018 <gilje@ualberta.ca> : Allow use of local version of cmake.
+# Author K E Gilje - 08/05/2019 <gilje@ualberta.ca> : Update cmake version for Root6.
 ####################################################################################################
 
 from distutils.version import StrictVersion

--- a/versions/cmakeversions.py
+++ b/versions/cmakeversions.py
@@ -8,6 +8,15 @@
 ####################################################################################################
 import cmake
 
+class Cmake3143(cmake.Cmake):
+    """ Cmake 3.14.3, install package."""
+    def __init__(self, system):
+        """ Initiliase the cmake 3.14.3 package."""
+        super(Cmake3143, self).__init__("cmake-3.14.3", system, "cmake-3.14.3.tar.gz")
+    def _download(self):
+        """ Download the 3.14.3 version."""
+        self._system.download_file("http://www.cmake.org/files/v3.14/" + self._tar_name)
+
 class Cmake2812(cmake.Cmake):
     """ Cmake 2.8.12, install package."""
     def __init__(self, system):

--- a/versions/rootversions.py
+++ b/versions/rootversions.py
@@ -9,6 +9,7 @@
 # Author P G Jones - 22/09/2012 <p.g.jones@qmul.ac.uk> : Major refactor of snoing.
 #        M Mottram - 20/10/2012 <m.mottram@sussex.ac.uk> : Added 5.34.02
 # Author P G Jones - 02/07/2013 <p.g.jones@qmul.ac.uk> : Added 5.34.08
+# Author K E gilje - 08/05/2019 <gilje@ualberta.ca> : Added Root 6.16/00
 ####################################################################################################
 
 import root
@@ -19,6 +20,13 @@ class ROOT5Dev(root.RootDevelopment):
     def __init__(self, system):
         """Initiliase the ROOT 5 development package."""
         super(ROOT5Dev, self).__init__('root-5-dev', system)
+
+
+class ROOT61600(root.RootPost60608):
+    """Root 6.16.00, install package."""
+    def __init__(self, system):
+        """Initiliase the root 6.16.00 package."""
+        super(ROOT61600, self).__init__('root-6.16.00', system, 'root_v6.16.00.source.tar.gz') 
 
 
 class ROOT60304(root.Root):


### PR DESCRIPTION
This allows users to install more recent root 6 versions.  It requires a newer cmake.

To build RAT against Root6, both Root6 and Geant must be installed with GCC 4.8.5.  GCC versions above 5 will BREAK the build.  This is a known RAT issue.